### PR TITLE
Update clj-http version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pdclient "0.1.3"
+(defproject pdclient "0.1.4"
   :description "pagerduty"
   :url "https://github.com/danielribeiro/PdClojureBindings"
   :license {:name "The MIT License"
@@ -7,7 +7,7 @@
   :warn-on-reflection false
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-http "1.1.2"]
+                 [clj-http "2.0.0"]
                  [cheshire "5.5.0"]
                  ]
   )


### PR DESCRIPTION
This removes a compatibility issue with Clojure 1.7.0:
   WARNING: update already refers to: #'clojure.core/update in namespace: clj-http.client, being replaced by: #'clj-http.client/update